### PR TITLE
Potential fix for code scanning alert no. 37: Flask app is run in debug mode

### DIFF
--- a/api_server.py
+++ b/api_server.py
@@ -717,4 +717,5 @@ if __name__ == '__main__':
     print("🔍 Module search available at: http://localhost:8000/api/search?q=<query>")
     print("📁 Code viewer available at: http://localhost:8000/code/<path>")
     
-    app.run(host='0.0.0.0', port=8000, debug=True)
+    debug_mode = os.environ.get('FLASK_DEBUG', '0').lower() in ('1', 'true', 'yes')
+    app.run(host='0.0.0.0', port=8000, debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/manan45/autodoc/security/code-scanning/37](https://github.com/manan45/autodoc/security/code-scanning/37)

To resolve the problem securely and correctly, you should change the `app.run()` statement in `api_server.py` so that `debug=True` is not hard-coded. Instead, only enable debug mode when the application is known to run in a development environment, such as when an environment variable (e.g., `FLASK_DEBUG`) is set to `'1'` or `'true'`. 

The best way to achieve this is:

- Read an environment variable (`FLASK_DEBUG`) near where `app.run()` is called.
- Set `debug=True` only if the environment variable explicitly requests it; otherwise, run with `debug=False` (or omit the argument for the default).
- This preserves existing functionality for development, but blocks debug mode in production.
- Requires an import of `os` if not already present (already imported).
- Change only the block at the bottom of `api_server.py` (lines 714–721): add the environment variable check and change the `app.run(...)` statement.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
